### PR TITLE
Add GitHub Action to auto push to Helm Registry

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,4 +1,4 @@
-name: AutoTag
+name: AutoRelease
 
 on:
   push:
@@ -6,18 +6,61 @@ on:
       - master
 
 jobs:
-  test:
+  release:
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v1
 
-    - name: Git Tag
+    - name: tag releases in git
+      id: git_tag
       run: |
         CHART_VERSION=$(cat Chart.yaml | grep version | awk '{ print $2 }')
+        echo "##[set-output name=version;]${CHART_VERSION}"
+
+        CHART_NAME=$(cat Chart.yaml | grep name | awk '{ print $2 }')
+        echo "##[set-output name=name;]${CHART_NAME}"
 
         git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
         git config --global user.name "${GITHUB_ACTOR}"
 
         git tag -a "v${CHART_VERSION}" -m "v${CHART_VERSION}" || true
         git push --tags "https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git"
+
+    - uses: actions/checkout@v1
+      with:
+        repository: evry-ace/helm-charts
+        ref: master
+        submodules: recursive
+
+    - name: push to evry-ace/helm-charts
+      run: |
+        cd ../helm-charts; pwd; ls -la
+
+        git fetch origin
+        git checkout -b "${CHART_NAME}/v${CHART_VERSION}" origin/master
+
+        # Update submodule
+        cd ${CHART_NAME}
+        git fetch origin
+        git checkout "v${CHART_VERSION}"
+        GIT_LOG="$(git log $(git describe --tags HEAD~)..HEAD --oneline | xargs)"
+
+        # Commit and push
+        cd ..
+        git status
+        if [[ `git status --porcelain` ]]; then
+          git add ${CHART_NAME}
+          git commit \
+            -m "${CHART_NAME}: release v${CHART_VERSION}" \
+            -m 'Changes since last release:' \
+            -m '```' \
+            -m "${GIT_LOG}" \
+            -m '```'
+
+          git push -u "https://${{ secrets.GITHUB_PAT }}@github.com/evry-ace/helm-charts.git" "${CHART_NAME}/v${CHART_VERSION}"
+        fi
+
+      env:
+        CHART_VERSION: ${{ steps.git_tag.outputs.version }}
+        CHART_NAME: ${{ steps.git_tag.outputs.name }}

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.3"
 description: Istio Bookinfo Helm chart for Kubernetes
 name: istio-bookinfo
-version: 1.2.1
+version: 1.2.2


### PR DESCRIPTION
Automatically create a new branch in github.com/evry-ace/helm-registry to publish any new versions of this Helm Chart to the ACE Helm Chart Registry.